### PR TITLE
404 if publication not found

### DIFF
--- a/src/modules/Clip/lib/Clip/Controller/User.php
+++ b/src/modules/Clip/lib/Clip/Controller/User.php
@@ -54,7 +54,6 @@ class Clip_Controller_User extends Zikula_AbstractController
         }
 
         if (!Clip_Util::validateTid($args['tid'])) {
-            LogUtil::registerError($this->__('Page not found'));
             return LogUtil::registerError($this->__f('Error! Invalid publication type ID passed [%s].', DataUtil::formatForDisplay($args['tid'])), 404);
         }
 


### PR DESCRIPTION
I think it is better to return a 404 error to the user if the user calls a invalid url.
