### PR TITLE
Add a page locker while editing an existing pub

### DIFF
--- a/lib/Clip/Form/Handler/User/Pubedit.php
+++ b/lib/Clip/Form/Handler/User/Pubedit.php
@@ -115,7 +115,6 @@ class Clip_Form_Handler_User_Pubedit extends Zikula_Form_AbstractHandler
 
         // Pagelock: Set locker when editing existing pub
         if ($this->pub->exists() && ModUtil::available('PageLock')) {
-            //$returnUrl = ($returnurl) ? $returnurl : 
             ModUtil::apiFunc('PageLock', 'user', 'pageLock', array('lockName' => "clipEditPub{$this->tid}-{$this->pid}",
                                                                    'returnUrl' => System::getCurrentUrl() ));
         }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | none |
| License | MIT |

Block the edit function using Zikula Core PageLock, if somebody is already editing the same page.
I have tested this code using Clip 0.9.4 for zk1.3.x
Philippe
